### PR TITLE
technically more correct error handling with http.ResponseWriter

### DIFF
--- a/gopages/game.go
+++ b/gopages/game.go
@@ -57,7 +57,7 @@ type gameInfo struct {
 var fallBackAlert = "<div><p class=\"text-danger\">Unknown failure. Contanct admin</p></div>"
 
 // RenderGamePage : renders the game input form page with correct data
-func RenderGamePage(db *sqlx.DB, w http.ResponseWriter, r *http.Request) (template.HTML, error) {
+func RenderGamePage(db *sqlx.DB, r *http.Request) (template.HTML, error) {
 	r.ParseForm()
 	var AlertMessage template.HTML
 	if len(r.PostForm) > 0 {
@@ -118,12 +118,10 @@ func RenderGamePage(db *sqlx.DB, w http.ResponseWriter, r *http.Request) (templa
 
 	t, err := template.ParseFiles("webpage/game_input/game_template.html")
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return template.HTML(""), err
 	}
 	var buff bytes.Buffer
 	if err = t.Execute(&buff, g); err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return template.HTML(""), err
 	}
 	return template.HTML(buff.String()), nil

--- a/gopages/games.go
+++ b/gopages/games.go
@@ -53,16 +53,14 @@ type gamesInfo struct {
 }
 
 // RenderGamesPage : gets data from db to show last 10 games played
-func RenderGamesPage(db *sqlx.DB, w http.ResponseWriter, r *http.Request) (template.HTML, error) {
+func RenderGamesPage(db *sqlx.DB, r *http.Request) (template.HTML, error) {
 	t, err := template.ParseFiles("webpage/games_view/games_template.html")
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return template.HTML(""), err
 	}
 	g := getGames(db)
 	var buff bytes.Buffer
 	if err = t.Execute(&buff, g); err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return template.HTML(""), err
 	}
 	return template.HTML(buff.String()), nil

--- a/gopages/player.go
+++ b/gopages/player.go
@@ -43,7 +43,7 @@ type playerInfo struct {
 }
 
 // RenderPlayerPage : renders the game input form page with correct data
-func RenderPlayerPage(db *sqlx.DB, w http.ResponseWriter, r *http.Request) (template.HTML, error) {
+func RenderPlayerPage(db *sqlx.DB, r *http.Request) (template.HTML, error) {
 	r.ParseForm()
 	var AlertMessage template.HTML
 	if len(r.PostForm) > 0 {
@@ -77,12 +77,10 @@ func RenderPlayerPage(db *sqlx.DB, w http.ResponseWriter, r *http.Request) (temp
 
 	t, err := template.ParseFiles("webpage/player_input/player_template.html")
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return template.HTML(""), err
 	}
 	var buff bytes.Buffer
 	if err = t.Execute(&buff, g); err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return template.HTML(""), err
 	}
 	return template.HTML(buff.String()), nil

--- a/gopages/standings.go
+++ b/gopages/standings.go
@@ -47,16 +47,14 @@ type standingsInfo struct {
 }
 
 // RenderStandingsPage : gets data from db to show current standings of known players
-func RenderStandingsPage(db *sqlx.DB, w http.ResponseWriter, r *http.Request) (template.HTML, error) {
+func RenderStandingsPage(db *sqlx.DB, r *http.Request) (template.HTML, error) {
 	t, err := template.ParseFiles("webpage/index_template.html")
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return template.HTML(""), err
 	}
 	g := getStandings(db)
 	var buff bytes.Buffer
 	if err = t.Execute(&buff, g); err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return template.HTML(""), err
 	}
 	return template.HTML(buff.String()), nil

--- a/phoos_server.go
+++ b/phoos_server.go
@@ -57,30 +57,33 @@ func gameHandler(env *util.Env, w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 	} else {
-		p.Body, err = gopages.RenderGamePage(env.DB, w, r)
+		p.Body, err = gopages.RenderGamePage(env.DB, r)
 		if err != nil {
-			return
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		} else {
+			serveTemplate(w, p)
 		}
-		serveTemplate(w, p)
 	}
 }
 
 func gamesHandler(env *util.Env, w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("content-type", "text/html")
-	body, err := gopages.RenderGamesPage(env.DB, w, r)
+	body, err := gopages.RenderGamesPage(env.DB, r)
 	if err != nil {
-		return
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	} else {
+		serveTemplate(w, &util.Page{Title: "Games", Body: body})
 	}
-	serveTemplate(w, &util.Page{Title: "Games", Body: body})
 }
 
 func playerHandler(env *util.Env, w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("content-type", "text/html")
-	body, err := gopages.RenderPlayerPage(env.DB, w, r)
+	body, err := gopages.RenderPlayerPage(env.DB, r)
 	if err != nil {
-		return
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	} else {
+		serveTemplate(w, &util.Page{Title: "Player", Body: body})
 	}
-	serveTemplate(w, &util.Page{Title: "Player", Body: body})
 }
 
 func playersHandler(env *util.Env, w http.ResponseWriter, r *http.Request) {
@@ -88,18 +91,20 @@ func playersHandler(env *util.Env, w http.ResponseWriter, r *http.Request) {
 	body := gopages.GetAllPlayers(env.DB)
 	b, err := json.Marshal(body)
 	if err != nil {
-		log.Fatal(err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	} else {
+		fmt.Fprint(w, string(b))
 	}
-	fmt.Fprint(w, string(b))
 }
 
 func indexHandler(env *util.Env, w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("content-type", "text/html")
-	body, err := gopages.RenderStandingsPage(env.DB, w, r)
+	body, err := gopages.RenderStandingsPage(env.DB, r)
 	if err != nil {
-		return
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	} else {
+		serveTemplate(w, &util.Page{Title: "Standings", Body: body})
 	}
-	serveTemplate(w, &util.Page{Title: "Standings", Body: body})
 }
 
 func defaultHandler(env *util.Env, w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
docs say to not to write to http.ResponseWriter after returning an error. This cleans that up and prevents that scenario from happening (serveTemplate is the one exception, but error writing there is the last point at which we write so what ever was partially written by template will have stopped and then be thrown out with the call to http.Error()).